### PR TITLE
Feature offline mode, run local models when offline

### DIFF
--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -79,6 +79,11 @@ def cli(interpreter):
                       action='store_true',
                       default=LOCAL_RUN,
                       help='run fully local with code-llama')
+  parser.add_argument('-o',
+                      '--offline',
+                      action='store_true',
+                      default=False,
+                      help='if you want to run in offline (use if you have no internet)')
   parser.add_argument(
                       '--falcon',
                       action='store_true',
@@ -138,6 +143,8 @@ def cli(interpreter):
   # Modify interpreter according to command line flags
   if args.yes:
     interpreter.auto_run = True
+  if args.offline:
+    interpreter.offline = True
   if args.fast:
     interpreter.model = "gpt-3.5-turbo"
   if args.local and not args.falcon:
@@ -148,7 +155,22 @@ def cli(interpreter):
     # This way, when folks hit interpreter --local, they get the same experience as before.
     
     rprint('', Markdown("**Open Interpreter** will use `Code Llama` for local execution. Use your arrow keys to set up the model."), '')
-        
+    if interpreter.offline:
+      models = {}
+      # get all models in the models folder
+      user_data_dir = appdirs.user_data_dir("Open Interpreter")
+      default_path = os.path.join(user_data_dir, "models")
+
+      # Ensure the directory exists
+      os.makedirs(default_path, exist_ok=True)
+      # get all models in the models folder
+      for file in os.listdir(default_path):
+        # if the file ends in .gguf it is a model
+        if file.endswith(".gguf"):
+          # get the model name
+          model_name = file[:-5]
+          # add it to the models dict
+          models[model_name] = model_name
     models = {
         '7B': 'TheBloke/CodeLlama-7B-Instruct-GGUF',
         '13B': 'TheBloke/CodeLlama-13B-Instruct-GGUF',

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -40,12 +40,17 @@ def get_hf_llm(repo_id, debug_mode, context_window, offline_mode):
         # get the local models instead
         print("Offline mode enabled. Using local model.")
         from llama_cpp import Llama
-        #  TODO: make this path configurable
-        # should not be hardcoded to jeff's path, we've already selected the model and assigned it to interpreter.model in cli.py
-        # we should just use that, or we have the repo_id here, so we can just use that to find the model in the local directory
-        # none of which have wanted to work for me so far, so I'm just hardcoding it for now
-        llama_2 = Llama(model_path="C:/Users/Jeff/AppData/Local/Open Interpreter/Open Interpreter/models/codellama-7b-instruct.Q2_K.gguf", # just hardcode jeff's path for now
-                        n_gpu_layers=-1, verbose=debug_mode, n_ctx=context_window)
+        # get the appdirectories path and add on the selected model
+        user_data_dir = appdirs.user_data_dir("Open Interpreter")
+        default_path = os.path.join(user_data_dir, "models")
+        model_path = os.path.join(default_path, repo_id)
+        # replace \ with \\ for windows and add the .gguf extension
+        model_path = model_path.replace("\\", "\\\\")
+        model_path += ".gguf"
+        # print(Markdown(f"Model found at `{model_path}`"))
+
+        llama_2 = Llama(model_path=model_path,
+                        verbose=debug_mode, n_ctx=context_window)
         return llama_2
 
     if "TheBloke/CodeLlama-" not in repo_id:

--- a/interpreter/get_hf_llm.py
+++ b/interpreter/get_hf_llm.py
@@ -30,8 +30,23 @@ import os
 import shutil
 from huggingface_hub import list_files_info, hf_hub_download
 
+offline = False
 
-def get_hf_llm(repo_id, debug_mode, context_window):
+def get_hf_llm(repo_id, debug_mode, context_window, offline_mode):
+
+    if offline_mode:
+        global offline
+        offline = True
+        # get the local models instead
+        print("Offline mode enabled. Using local model.")
+        from llama_cpp import Llama
+        #  TODO: make this path configurable
+        # should not be hardcoded to jeff's path, we've already selected the model and assigned it to interpreter.model in cli.py
+        # we should just use that, or we have the repo_id here, so we can just use that to find the model in the local directory
+        # none of which have wanted to work for me so far, so I'm just hardcoding it for now
+        llama_2 = Llama(model_path="C:/Users/Jeff/AppData/Local/Open Interpreter/Open Interpreter/models/codellama-7b-instruct.Q2_K.gguf", # just hardcode jeff's path for now
+                        n_gpu_layers=-1, verbose=debug_mode, n_ctx=context_window)
+        return llama_2
 
     if "TheBloke/CodeLlama-" not in repo_id:
       # ^ This means it was prob through the old --local, so we have already displayed this message.

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -116,6 +116,7 @@ class Interpreter:
     self.azure_api_version = None
     self.azure_deployment_name = None
     self.azure_api_type = "azure"
+    self.offline = False
     
     # Get default system message
     here = os.path.abspath(os.path.dirname(__file__))
@@ -332,7 +333,7 @@ class Interpreter:
 
         # Find or install Code-Llama
         try:
-          self.llama_instance = get_hf_llm(self.model, self.debug_mode, self.context_window)
+          self.llama_instance = get_hf_llm(self.model, self.debug_mode, self.context_window, self.offline)
           if self.llama_instance == None:
             # They cancelled.
             return


### PR DESCRIPTION
### Describe the changes you have made:
Added a new command line arguement for if you want to run in offline mode --offline, made changes to the loading and selecting of local models to allow for loading a local model when there is no internet connection found in the open interpreter models folder

here is a gif of the functionality only able to test on windows
![interpreter_21](https://github.com/KillianLucas/open-interpreter/assets/25391741/e74b9e71-e2e3-424f-9a5f-35a4ed70af9c)


### Reference any relevant issue (Fixes #000)
fixes #281

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [x] Windows
- [ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [x] Llama 7B
- [x] Llama 13B
- [x] Llama 34B
- [x] Huggingface model (maybe all predownloaded offline ones)
