### PR TITLE
add `config` as a option parameter of Interpreter __init__ function

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -20,7 +20,7 @@ class Interpreter:
     def cli(self):
         cli(self)
 
-    def __init__(self):
+    def __init__(self, config=None):
         # State
         self.messages = []
         self._code_interpreters = {}
@@ -48,7 +48,8 @@ class Interpreter:
         self._llm = None
 
         # Load config defaults
-        config = get_config()
+        if config is None:
+            config = get_config()
         self.__dict__.update(config)
 
         # Check for update


### PR DESCRIPTION
### Describe the changes you have made:
I have introduced `config` as a optional parameter in the Interpreter's `__init__` function. This change was necessary to eliminate confusion that arose when an `Interpreter` instance was initialized with `system_message` and `model` among others, yet upon reviewing the source code, it appeared that nothing was passed into the `__init__` function.

### Reference any relevant issue (Fixes #000)
None

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [x] Linux

### AI Language Model (if applicable)
- [] GPT4
- [] GPT3
- [] Llama 7B
- [] Llama 13B
- [] Llama 34B
- [] Huggingface model (Please specify which one)
