### PR TITLE
Magic command defaults upgrade + delete messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ We welcome code contributions through pull requests. Here are some guidelines:
 
 - Open a PR to `main` linking any related issues. Provide detailed context on your changes.
 
+- Add your `OPENAI_API_KEY` environment variable to the repository secrets to make sure your tests can pass.
+
 - We will review PRs when possible and work with you to integrate your contribution. Please be patient as reviews take time. 
 
 - Once approved, your code will be merged - thank you for improving Open Interpreter!

--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -1,6 +1,7 @@
 from ..utils.display_markdown_message import display_markdown_message
 import json
 import os
+import datetime
 
 def handle_undo(self, arguments):
     # Removes all messages after the most recent user entry (and the entry itself).
@@ -82,7 +83,13 @@ def default_handle(self, arguments):
 
 def handle_save_message(self, json_path):
     if json_path == "":
-      json_path = "messages.json"
+      now = datetime.datetime.now()
+      msg_counter = 0
+      while True:
+        json_path = now.strftime("%Y-%m-%d") + "_messages_" + str(msg_counter) + ".json"
+        if not os.path.exists(json_path):
+          break
+        msg_counter += 1
     if not json_path.endswith(".json"):
       json_path += ".json"
     with open(json_path, 'w') as f:

--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -2,6 +2,7 @@ from ..utils.display_markdown_message import display_markdown_message
 import json
 import os
 import datetime
+import glob
 
 def handle_undo(self, arguments):
     # Removes all messages after the most recent user entry (and the entry itself).
@@ -98,8 +99,13 @@ def handle_save_message(self, json_path):
     display_markdown_message(f"> messages json export to {os.path.abspath(json_path)}")
 
 def handle_load_message(self, json_path):
-    if json_path == "":
-      json_path = "messages.json"
+    if not json_path:
+      json_paths = glob.glob("*_messages_*.json")
+      if json_paths:
+        latest_path = max(json_paths, key=os.path.getmtime)
+        json_path = latest_path
+      else:
+        json_path = "messages.json"
     if not json_path.endswith(".json"):
       json_path += ".json"
     with open(json_path, 'r') as f:

--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -40,8 +40,9 @@ def handle_help(self, arguments):
       "%debug [true/false]": "Toggle debug mode. Without arguments or with 'true', it enters debug mode. With 'false', it exits debug mode.",
       "%reset": "Resets the current session.",
       "%undo": "Remove previous messages and its response from the message history.",
-      "%save_message [path]": "Saves messages to a specified JSON path. If no path is provided, it defaults to 'messages.json'.",
-      "%load_message [path]": "Loads messages from a specified JSON path. If no path is provided, it defaults to 'messages.json'.",
+      "%save_message [path]": "Saves messages to a specified JSON path. If no path is provided, it defaults to '[date]_messages_[counter].json'.",
+      "%load_message [path]": "Loads messages from a specified JSON path. If no path is provided, it loads the latest default message '[date]_messages_[counter].json'.",
+      "%delete_message [number]": "Deletes saved messages, preserving the most recent 'number' files. If no number is provided, it deletes all but the most recent file.",
       "%help": "Show this help message.",
     }
 
@@ -115,7 +116,7 @@ def handle_load_message(self, json_path):
   
 def handle_delete_messages(self, num_to_keep):
   if num_to_keep == "":
-    num_to_keep = "0"
+    num_to_keep = "1"
   num_to_keep = int(num_to_keep)
   print(num_to_keep)
   json_paths = glob.glob("*_messages_*.json")

--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -112,6 +112,29 @@ def handle_load_message(self, json_path):
       self.messages = json.load(f)
 
     display_markdown_message(f"> messages json loaded from {os.path.abspath(json_path)}")
+  
+def handle_delete_messages(self, num_to_keep):
+  if num_to_keep == "":
+    num_to_keep = "0"
+  num_to_keep = int(num_to_keep)
+  print(num_to_keep)
+  json_paths = glob.glob("*.json")
+  print(json_paths)
+  if len(json_paths) <= num_to_keep:
+    print("No files to delete")
+    return
+  json_paths.sort(key=os.path.getmtime)
+  print(json_paths)
+  if num_to_keep < 0:
+    print("Number of files to keep must be positive")
+    return
+  elif num_to_keep > 0:
+    json_paths = json_paths[:-num_to_keep]
+  print(json_paths)
+  for path in json_paths:
+    os.remove(path)
+  print(f"Deleted {len(json_paths)} old json files")  
+   
 
 def handle_magic_command(self, user_input):
     # split the command into the command and the arguments, by the first whitespace
@@ -121,6 +144,7 @@ def handle_magic_command(self, user_input):
       "reset": handle_reset,
       "save_message": handle_save_message,
       "load_message": handle_load_message,
+      "delete_messages": handle_delete_messages,
       "undo": handle_undo,
     }
 

--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -118,7 +118,7 @@ def handle_delete_messages(self, num_to_keep):
     num_to_keep = "0"
   num_to_keep = int(num_to_keep)
   print(num_to_keep)
-  json_paths = glob.glob("*.json")
+  json_paths = glob.glob("*_messages_*.json")
   print(json_paths)
   if len(json_paths) <= num_to_keep:
     print("No files to delete")


### PR DESCRIPTION
### The problem:
Magic commands previously saved to and overwrote message.json by default. The problem is:

1. You want to save messages quickly, but you don't necessarily want it to overwrite.
2. The name message.json is uninformative - you know nothing about the contents.
3. The message JSONs are also small, so storing multiple past conversations easily outweighs the cons.

### Relevant issue
Fixes #564 

### The Fix:

1. Updated the save name convention to be `[date]_messages_[counter].json` when no path is provided.
2. Loads the latest message `[date]_messages_[counter].json` when no path is provided.
3. Added %delete_messages to let you clean up historical messages, which accepts a parameter (for the number of files you wish to preserve) - or deletes everything except the most recent file by default.
4. Updated the `handle_help` function to reflect the changes.

With this approach, you can still save the messages quickly without overwriting. The names also include the date so you're able to get more information about the file (albeit nothing too in-depth). If you wish to clear out previous messages, you can also do that now too.

### Testing
- [ ✅] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [✅ ] MacOS
- [ ] Linux

### AI Language Model (if applicable)
N/A
