### PR TITLE
[WIP] feat: allow editing of code blocks before execution

### DIFF
--- a/interpreter/cli/cli.py
+++ b/interpreter/cli/cli.py
@@ -1,10 +1,8 @@
 import argparse
-import subprocess
 import os
-import platform
 import pkg_resources
 import appdirs
-from ..utils.display_markdown_message import display_markdown_message
+from ..utils.open_file import open_file
 from ..terminal_interface.conversation_navigator import conversation_navigator
 
 arguments = [
@@ -114,16 +112,9 @@ def cli(interpreter):
         config_dir = appdirs.user_config_dir("Open Interpreter")
         config_path = os.path.join(config_dir, 'config.yaml')
         print(f"Opening `{config_path}`...")
-        # Use the default system editor to open the file
-        if platform.system() == 'Windows':
-            os.startfile(config_path)  # This will open the file with the default application, e.g., Notepad
-        else:
-            try:
-                # Try using xdg-open on non-Windows platforms
-                subprocess.call(['xdg-open', config_path])
-            except FileNotFoundError:
-                # Fallback to using 'open' on macOS if 'xdg-open' is not available
-                subprocess.call(['open', config_path])
+        
+        open_file(file_path=config_path)
+
         return
     
     # TODO Implement model explorer

--- a/interpreter/code_interpreters/languages/utils/language_tools.py
+++ b/interpreter/code_interpreters/languages/utils/language_tools.py
@@ -1,0 +1,25 @@
+from ...language_map import language_map
+
+
+def get_language_file_extension(language_name):
+    """
+    Get the file extension for a given language
+    """
+    language = language_map[language_name.lower()]
+
+    if language.file_extension:
+        return language.file_extension
+    else:
+        return language
+
+
+def get_language_proper_name(language_name):
+    """
+    Get the proper name for a given language
+    """
+    language = language_map[language_name.lower()]
+
+    if language.proper_name:
+        return language.proper_name
+    else:
+        return language

--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -90,6 +90,14 @@ def respond(interpreter):
                 print("Running code:", interpreter.messages[-1])
 
             try:
+                # Yield a message, such that the user can stop code execution if they want to
+                try:
+                    yield {"executing": {"code": interpreter.messages[-1]["code"], "language": interpreter.messages[-1]["language"]}}
+                except GeneratorExit:
+                    # The user might exit here.
+                    # We need to tell python what we (the generator) should do if they exit
+                    break
+
                 # What code do you want to run?
                 code = interpreter.messages[-1]["code"]
 
@@ -105,13 +113,6 @@ def respond(interpreter):
                     interpreter._code_interpreters[language] = create_code_interpreter(language)
                 code_interpreter = interpreter._code_interpreters[language]
 
-                # Yield a message, such that the user can stop code execution if they want to
-                try:
-                    yield {"executing": {"code": code, "language": language}}
-                except GeneratorExit:
-                    # The user might exit here.
-                    # We need to tell python what we (the generator) should do if they exit
-                    break
 
                 # Yield each line, also append it to last messages' output
                 interpreter.messages[-1]["output"] = ""

--- a/interpreter/utils/edit_code.py
+++ b/interpreter/utils/edit_code.py
@@ -1,0 +1,64 @@
+import os
+from yaspin import yaspin
+
+from .temporary_file import create_temporary_file, cleanup_temporary_file
+from .open_file import open_file
+from ..code_interpreters.languages.utils.language_tools import get_language_file_extension, get_language_proper_name
+
+
+def edit_code(code, language, interpreter):
+    """
+    Edit the code and listen for changes with watchdog
+    """
+
+    temp_code = code
+
+    temp_file = create_temporary_file(
+        temp_code, get_language_file_extension(language), verbose=interpreter.debug_mode
+    )
+
+    language_name = get_language_proper_name(language)
+
+    file_name = os.path.basename(temp_file)
+
+    if interpreter.debug_mode:
+        print(f"Editing {language_name} code in {file_name}")
+        print("---")
+
+    # Run semgrep
+    try:
+        print("  Press `ENTER` after you've saved your edits.")
+
+        open_file(temp_file)
+
+        with yaspin(text=f"  Editing {language_name} code...").green.right.dots as loading:
+            # HACK: we're just listening for the user to come back and hit Enter
+            # but we aren't actually doing anything with it and since we're inside
+            # of a yaspin handler, the input prompt doesn't actually render
+            done = input("  Press `ENTER` when you're ready to continue:")
+
+            loading.stop()
+            loading.hide()
+
+        if done == "":
+            print(f"  {language_name} code updated.")
+            print("") # <- Aesthetic choice
+
+            temp_code = open(temp_file).read()
+
+            if interpreter.debug_mode:
+                print(f"Getting updated {language_name} code from {file_name}")
+                print("---")
+
+            cleanup_temporary_file(temp_file, verbose=interpreter.debug_mode)
+
+            if interpreter.debug_mode:
+                print(f"Deleting {file_name}")
+                print("---")
+
+    except Exception as e:
+        print(f"Could not edit {language} code.")
+        print(e)
+        print("")  # <- Aesthetic choice
+
+    return temp_code

--- a/interpreter/utils/open_file.py
+++ b/interpreter/utils/open_file.py
@@ -1,0 +1,14 @@
+import os
+import platform
+import subprocess
+
+def open_file(file_path):
+    if platform.system() == 'Windows':
+        os.startfile(file_path)  # This will open the file with the default application, e.g., Notepad
+    else:
+        try:
+            # Try using xdg-open on non-Windows platforms
+            subprocess.call(['xdg-open', file_path])
+        except FileNotFoundError:
+            # Fallback to using 'open' on macOS if 'xdg-open' is not available
+            subprocess.call(['open', file_path])

--- a/interpreter/utils/scan_code.py
+++ b/interpreter/utils/scan_code.py
@@ -1,34 +1,9 @@
 import os
 import subprocess
 from yaspin import yaspin
-from yaspin.spinners import Spinners
 
 from .temporary_file import create_temporary_file, cleanup_temporary_file
-from ..code_interpreters.language_map import language_map
-
-
-def get_language_file_extension(language_name):
-    """
-    Get the file extension for a given language
-    """
-    language = language_map[language_name.lower()]
-
-    if language.file_extension:
-        return language.file_extension
-    else:
-        return language
-
-
-def get_language_proper_name(language_name):
-    """
-    Get the proper name for a given language
-    """
-    language = language_map[language_name.lower()]
-
-    if language.proper_name:
-        return language.proper_name
-    else:
-        return language
+from ..code_interpreters.languages.utils.language_tools import get_language_file_extension, get_language_proper_name
 
 
 def scan_code(code, language, interpreter):


### PR DESCRIPTION
### Describe the changes you have made:

This work-in-progress introduces the ability to edit code in your default editor before running it.

When Open Interpreter asks if you want to run the provided code, there is a new option, `%edit`, which will allow you to edit the code.

It currently waits for you to come back and hit `ENTER` to continue execution.

Unfortunately, it seems to automatically run the edited code, and I haven't been able to get it back into the `scan`/`run` loop.

I tried using a few different file/directory watching Python packages, but it seems the file close event is not very easy to listen for and not consistent across platforms, so for the initial proof of concept, I’m relying on user intervention.

#### Demo

![OpenInterpreter-Edit-Code](https://github.com/KillianLucas/open-interpreter/assets/1667415/5773eaad-5362-4599-8324-095fd197585b)

#### Testing Instructions

1. `gh pr checkout https://github.com/KillianLucas/open-interpreter/pull/612`
2. `poetry run interpreter`
   **Note**: `auto_run` must be disabled so don't run it with `-y` or with `auto_run: true` in your `config.yaml`.
3. Provide an input that generates code
   **Example**:
   > Solve FizzBuzz for 0 through 17. Don't explain the code or tell me your process or how FizzBuzz works. Just generate the code so we can execute it.
4. When asked if you want to run the code, enter the `%edit` magic command
5. Edit the code and save your changes
6. Come back to the Terminal and hit `ENTER`

### Reference any relevant issue (Fixes #537)

- [x] I have performed a self-review of my code:

### I have tested the code on the following OS:
- [ ] Windows
- [x] MacOS
- [ ] Linux

### AI Language Model (if applicable)
- [ ] GPT4
- [ ] GPT3
- [ ] Llama 7B
- [ ] Llama 13B
- [ ] Llama 34B
- [ ] Huggingface model (Please specify which one)
