### PR TITLE
fix for Files property missing on Computer module

### DIFF
--- a/interpreter/core/computer/computer.py
+++ b/interpreter/core/computer/computer.py
@@ -14,7 +14,7 @@ from .os.os import Os
 from .skills.skills import Skills
 from .sms.sms import SMS
 from .terminal.terminal import Terminal
-
+from .files.files import Files
 
 class Computer:
     def __init__(self, interpreter):
@@ -39,6 +39,7 @@ class Computer:
         self.skills = Skills(self)
         self.docs = Docs(self)
         self.ai = Ai(self)
+        self.files = Files(self)
 
         self.emit_images = True
         self.api_base = "https://api.openinterpreter.com/v0"


### PR DESCRIPTION
### Describe the changes you have made:
Import the missing Files module into the Computer module

### Reference any relevant issues (e.g. "Fixes #000"):
https://github.com/OpenInterpreter/open-interpreter/issues/1106

### Pre-Submission Checklist (optional but appreciated):

- [ n/a ] I have included relevant documentation updates (stored in /docs)
- [ x ] I have read `docs/CONTRIBUTING.md`
- [ x ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ x ] Tested on Linux
