### PR TITLE
Update `Github` → `GitHub`

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 **Open Interpreter is large, open-source initiative to build a standard interface between language models and computers.**
 
-There are many ways to contribute, from helping others on [GitHub](https://github.com/KillianLucas/open-interpreter/issues) or [Discord](https://discord.gg/6p3fD6rBVm), writing documentation, or improving code.
+There are many ways to contribute, from helping others on [GitHub](https://github.com/OpenInterpreter/open-interpreter/issues) or [Discord](https://discord.gg/6p3fD6rBVm), writing documentation, or improving code.
 
 We depend on contributors like you. Let's build this.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 **Open Interpreter is large, open-source initiative to build a standard interface between language models and computers.**
 
-There are many ways to contribute, from helping others on [Github](https://github.com/KillianLucas/open-interpreter/issues) or [Discord](https://discord.gg/6p3fD6rBVm), writing documentation, or improving code.
+There are many ways to contribute, from helping others on [GitHub](https://github.com/KillianLucas/open-interpreter/issues) or [Discord](https://discord.gg/6p3fD6rBVm), writing documentation, or improving code.
 
 We depend on contributors like you. Let's build this.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 **Open Interpreter is large, open-source initiative to build a standard interface between language models and computers.**
 
-There are many ways to contribute, from helping others on [GitHub](https://github.com/OpenInterpreter/open-interpreter/issues) or [Discord](https://discord.gg/6p3fD6rBVm), writing documentation, or improving code.
+There are many ways to contribute, from helping others on [GitHub](https://github.com/OpenInterpreter/open-interpreter/issues) or [Discord](https://discord.gg/Hvz9Axh84z), writing documentation, or improving code.
+
 
 We depend on contributors like you. Let's build this.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,7 +45,7 @@
 
 ## Future-proofing
 
-- [ ] Really good tests / optimization framework, to be run less frequently than Github actions tests
+- [ ] Really good tests / optimization framework, to be run less frequently than GitHub Actions tests
   - [x] Figure out how to run us on [GAIA](https://huggingface.co/gaia-benchmark)
     - [x] How do we just get the questions out of this thing?
     - [x] How do we assess whether or not OI has solved the task?


### PR DESCRIPTION
### Describe the changes you have made:
Little casing update for GitHub.
PS: The [landing page](https://www.openinterpreter.com/) also includes incorrect casing of GitHub but I can't find that open-sourced. Congrats on the launch!

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

N/A
