### PR TITLE
check that the message content is a string before calling strip()

### DIFF
--- a/interpreter/core/llm/utils/convert_to_openai_messages.py
+++ b/interpreter/core/llm/utils/convert_to_openai_messages.py
@@ -170,7 +170,8 @@ def convert_to_openai_messages(
         else:
             raise Exception(f"Unable to convert this message type: {message}")
 
-        new_message["content"] = new_message["content"].strip()
+        if isinstance(new_message["content"], str):
+            new_message["content"] = new_message["content"].strip()
 
         new_messages.append(new_message)
 


### PR DESCRIPTION
### Describe the changes you have made:

Checks the new message content's type before attempting to call `strip()`. In cases where a screenshot is being sent, `content` will be a list, not a string.

### Reference any relevant issues (e.g. "Fixes #000"):
- Fixes #1116

### Pre-Submission Checklist (optional but appreciated):

- [X] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
