### PR TITLE
fix(import_skills): fix AttributeError when checking import skills error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/interpreter/core/computer/skills/skills.py
+++ b/interpreter/core/computer/skills/skills.py
@@ -47,23 +47,25 @@ class Skills:
         if self.computer.interpreter.debug:
             print("IMPORTING SKILLS:\n", code_to_run)
 
-        output = self.computer.run("python", code_to_run)
+        outputs = self.computer.run("python", code_to_run)
 
-        if "traceback" in output.lower():
-            # Import them individually
-            for file in glob.glob(os.path.join(self.path, "*.py")):
-                with open(file, "r") as f:
-                    code_to_run = f.read() + "\n"
+        for output in outputs:
+            if type(output) == "str" and "traceback" in output.lower():
+                # Import them individually
+                for file in glob.glob(os.path.join(self.path, "*.py")):
+                    with open(file, "r") as f:
+                        code_to_run = f.read() + "\n"
 
-                if self.computer.interpreter.debug:
-                    print("IMPORTING SKILL:\n", code_to_run)
+                    if self.computer.interpreter.debug:
+                        print("IMPORTING SKILL:\n", code_to_run)
 
-                output = self.computer.run("python", code_to_run)
-
-                if "traceback" in output.lower():
-                    print(
-                        f"Skill at {file} might be broken— it produces a traceback when run."
-                    )
+                    outputs = self.computer.run("python", code_to_run)
+                    
+                    for output in outputs:
+                        if type(output) == "str" and "traceback" in output.lower():
+                            print(
+                                f"Skill at {file} might be broken— it produces a traceback when run."
+                            )
 
         self.computer.save_skills = previous_save_skills_setting
 


### PR DESCRIPTION
### Describe the changes you have made:

fix AttributeError when checking import skills error during launch, the output from computer.run() is a list, not a string, I used a for loop to iterate through all the outputs and looked for "traceback" like before.

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
