### PR TITLE
Added 'py' alias for Python/JupyterLanguage

### DIFF
--- a/interpreter/core/computer/terminal/languages/jupyter_language.py
+++ b/interpreter/core/computer/terminal/languages/jupyter_language.py
@@ -21,6 +21,7 @@ DEBUG_MODE = False
 class JupyterLanguage(BaseLanguage):
     file_extension = "py"
     name = "Python"
+    aliases = ["py"]
 
     def __init__(self, computer):
         self.computer = computer


### PR DESCRIPTION
### Describe the changes you have made:
Added "py" to aliases list on JupyterLangauge class

### Reference any relevant issues (e.g. "Fixes #000"):
https://discord.com/channels/1146610656779440188/1221178035378589776

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
