### PR TITLE
Check for GPU or MPS availability before using CPU

### DIFF
--- a/interpreter/core/computer/display/point/point.py
+++ b/interpreter/core/computer/display/point/point.py
@@ -490,7 +490,13 @@ if fast_model == False:
     # embeddings = embed_images(images, model, transforms)
 
 
-device = torch.device("cpu")  # or 'cpu' for CPU, 'cuda:0' for the first GPU, etc.
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
+
 # Move the model to the specified device
 model = model.to(device)
 


### PR DESCRIPTION
### Describe the changes you have made:

In `point.py`, check for GPU or MPS before defaulting to CPU.

### Reference any relevant issues (e.g. "Fixes #000"):

- Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1131


### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
