### PR TITLE
Add DevContainer Support

### DIFF
--- a/.devcontainer/DockerFile
+++ b/.devcontainer/DockerFile
@@ -1,0 +1,1 @@
+FROM python:3.11

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "Open Interpreter",
+	"dockerFile": "DockerFile",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	"onCreateCommand": "pip install .",
+	"postAttachCommand": "interpreter -y"
+	// Configure tool-specific properties.
+	// "customizations": {},
+}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ interpreter.chat() # Starts an interactive chat
 ```
 
 ### GitHub Codespaces
-Press the `.` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
+Press the `,` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
 
 ## Comparison to ChatGPT's Code Interpreter
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ interpreter.chat() # Starts an interactive chat
 ```
 
 ### GitHub Codespaces
+
 Press the `,` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
 
 ## Comparison to ChatGPT's Code Interpreter

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ interpreter.chat("Plot AAPL and META's normalized stock prices") # Executes a si
 interpreter.chat() # Starts an interactive chat
 ```
 
+### GitHub Codespaces
+Press the `.` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
+
 ## Comparison to ChatGPT's Code Interpreter
 
 OpenAI's release of [Code Interpreter](https://openai.com/blog/chatgpt-plugins#code-interpreter) with GPT-4 presents a fantastic opportunity to accomplish real-world tasks with ChatGPT.

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -61,4 +61,5 @@ interpreter.chat("Get the last 5 BBC news headlines.")
 [Click here](/usage/python/streaming-response) to learn how to stream its response into your application.
 
 ## No Installation
+
 If configuring your computer environment is challenging, you can press the `,` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -59,3 +59,6 @@ interpreter.chat("Get the last 5 BBC news headlines.")
 ```
 
 [Click here](/usage/python/streaming-response) to learn how to stream its response into your application.
+
+## No Installation
+If configuring your computer environment is challenging, you can press the `.` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -61,4 +61,4 @@ interpreter.chat("Get the last 5 BBC news headlines.")
 [Click here](/usage/python/streaming-response) to learn how to stream its response into your application.
 
 ## No Installation
-If configuring your computer environment is challenging, you can press the `.` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
+If configuring your computer environment is challenging, you can press the `,` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.


### PR DESCRIPTION
### Describe the changes you have made:
For users who have difficulties with local installation, they can skip the local installation step, only need to visit our repository's GitHub page and press the `,` key, and they can directly create a Codespace virtual container. The container comes pre-installed with open-interpreter and includes the vscode interface. Users can seamlessly start communicating with open-interpreter.

You can now give it a try:
Visit https://github.com/weihongliang233/open-interpreter-devcontainer, press `,` on the webpage to create a codespace, and then you can start communicating with open-interpreter!

More details:
[DevContainer and Codespaces](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers)

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
