### PR TITLE
Fix Jupyter logging on shutdown

### DIFF
--- a/interpreter/core/computer/terminal/languages/jupyter_language.py
+++ b/interpreter/core/computer/terminal/languages/jupyter_language.py
@@ -10,6 +10,7 @@ import re
 import threading
 import time
 import traceback
+import logging
 
 from jupyter_client import KernelManager
 
@@ -24,7 +25,17 @@ class JupyterLanguage(BaseLanguage):
 
     def __init__(self, computer):
         self.computer = computer
-
+        # Filter out the following messages from IPKernelApp, to prevent the logs from showing up anytime someone presses CTRL+C
+        if not DEBUG_MODE:
+            ipkernel_logger = logging.getLogger('IPKernelApp')
+            # Create a filter using a lambda function
+            warning_filter = lambda record: not any(msg in record.getMessage() for msg in [
+                "Parent appears to have exited, shutting down.",
+                "Could not destroy zmq context"
+            ])
+            # Add the filter to the logger
+            ipkernel_logger.addFilter(warning_filter)
+            
         self.km = KernelManager(kernel_name="python3")
         self.km.start_kernel()
         self.kc = self.km.client()


### PR DESCRIPTION
### Describe the changes you have made:

When open interpreter is shut down, it frequently logs a message that originates from Jupyter:

[IPKernelApp] WARNING | Parent appears to have exited, shutting down. 

This is not actually an error or an issue, just kind of annoying to see. It also has prompted folks to create issues about it, despite it being harmless. This just adds a simple filter to the logger messages from Jupyter to prevent the harmless messages from being logged on shutdown

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes #1125
### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
