### PR TITLE
Generate history conversation filenames in Chinese properly.

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -238,9 +238,11 @@ class OpenInterpreter:
             if self.conversation_history:
                 # If it's the first message, set the conversation name
                 if not self.conversation_filename:
-                    first_few_words = "_".join(
-                        self.messages[0]["content"][:25].split(" ")[:-1]
-                    )
+                    first_few_words_list = self.messages[0]["content"][:25].split(" ")
+                    if len(first_few_words_list) >= 2:  # for languages like English with blank between words
+                        first_few_words = "_".join(first_few_words_list[:-1])
+                    else:  # for languages like Chinese without blank between words
+                        first_few_words = self.messages[0]["content"][:15]
                     for char in '<>:"/\\|?*!':  # Invalid characters for filenames
                         first_few_words = first_few_words.replace(char, "")
 


### PR DESCRIPTION
### Describe the changes you have made:
There's a problem with generating history conversation filenames in Chinese and other languages without blanks between words for a long time. If users input their first request in languages like Chinese, they would get a history conversation json file named as something like `__March_28_2024_19-59-01.json` almost every time. This was caused by the old way to generate the first part of filename: `self.messages[0]["content"][:25].split(" ")[:-1]`. This would get a blank string if there's no `" "`(blank space) in users' first input. I made a small patch to fix this. Now it will name history conversation files like `这是一句中文__March_28_2024_19-59-01.json` if got users' first input in Chinese.

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
