### PR TITLE
Display Link to Docs with Unrecognized Flags

### DIFF
--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -303,7 +303,16 @@ def start_terminal_interface(interpreter):
                     nargs=arg.get("nargs"),
                 )
 
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
+
+    # handle unknown arguments
+    if unknown_args:
+        print(f"\nUnrecognized argument(s): {unknown_args}")
+        parser.print_usage()
+        print(
+            "For detailed documentation of supported arguments, please visit: https://docs.openinterpreter.com/settings/all-settings"
+        )
+        sys.exit(1)
 
     if args.profiles:
         open_storage_dir("profiles")
@@ -357,15 +366,21 @@ def start_terminal_interface(interpreter):
 
     ### Set some helpful settings we know are likely to be true
 
-    if interpreter.llm.model.startswith("gpt-4") or interpreter.llm.model.startswith("openai/gpt-4"):
+    if interpreter.llm.model.startswith("gpt-4") or interpreter.llm.model.startswith(
+        "openai/gpt-4"
+    ):
         if interpreter.llm.context_window is None:
             interpreter.llm.context_window = 128000
         if interpreter.llm.max_tokens is None:
             interpreter.llm.max_tokens = 4096
         if interpreter.llm.supports_functions is None:
-            interpreter.llm.supports_functions = False if "vision" in interpreter.llm.model else True
+            interpreter.llm.supports_functions = (
+                False if "vision" in interpreter.llm.model else True
+            )
 
-    if interpreter.llm.model.startswith("gpt-3.5-turbo") or interpreter.llm.model.startswith("openai/gpt-3.5-turbo"):
+    if interpreter.llm.model.startswith(
+        "gpt-3.5-turbo"
+    ) or interpreter.llm.model.startswith("openai/gpt-3.5-turbo"):
         if interpreter.llm.context_window is None:
             interpreter.llm.context_window = 16000
         if interpreter.llm.max_tokens is None:


### PR DESCRIPTION
### Describe the changes you have made:
When interpreter is run with an unrecognized flag such as `interpreter --this-does-not-exist` we receive a standard argparse error message. 

> usage: interpreter [-h] [-p PROFILE] [-ci CUSTOM_INSTRUCTIONS] [-s SYSTEM_MESSAGE] [-y] [-v] [-m MODEL] [-t TEMPERATURE] [-lsv | --llm_supports_vision | --no-llm_supports_vision] [-lsf | --llm_supports_functions | --no-llm_supports_functions] [-cw CONTEXT_WINDOW] [-x MAX_TOKENS] [-b MAX_BUDGET] [-ab API_BASE] [-ak API_KEY] [-av API_VERSION] [-xo MAX_OUTPUT] [-fc] [-dt] [-o] [-sm] [-safe {off,ask,auto}] [-debug] [-f] [-ml] [-l] [-vi] [-os] [--reset_profile [RESET_PROFILE]] [--profiles] [--local_models] [--conversations] [--server] [--version]
interpreter: error: unrecognized arguments: --this-does-not-exist

These changes modify `start_terminal_interface.py` to return a link to the docs in the error message if interpreter is called with an unrecognized flag. 

`interpreter --this-does-not-exist-yet` now returns the following:
> Unrecognized argument(s): ['--this-does-not-exist-yet']
usage: interpreter [-h] [-p PROFILE] [-ci CUSTOM_INSTRUCTIONS] [-s SYSTEM_MESSAGE] [-y] [-v] [-m MODEL] [-t TEMPERATURE] [-lsv | --llm_supports_vision | --no-llm_supports_vision] [-lsf | --llm_supports_functions | --no-llm_supports_functions]  [-cw CONTEXT_WINDOW] [-x MAX_TOKENS] [-b MAX_BUDGET] [-ab API_BASE] [-ak API_KEY] [-av API_VERSION] [-xo MAX_OUTPUT] [-fc] [-dt]  [-o] [-sm] [-safe {off,ask,auto}] [-debug] [-f] [-ml] [-l] [-vi] [-os] [--reset_profile [RESET_PROFILE]] [--profiles] [--local_models] [--conversations] [--server] [--version]
For detailed documentation of supported arguments, please visit: https://docs.openinterpreter.com/settings/all-settings

Please review for any feedback regarding error message format and if new tests should be added. Manual testing was done with existing flags to ensure these changes don't break anything but was not comprehensive. 

### Reference any relevant issues (e.g. "Fixes #000"):
Implements the feature request in issue **#1113 Display link to the Docs if error with flags**

### Pre-Submission Checklist (optional but appreciated):
Documentation was not updated since the feature handles error messages with unrecognized flags. Happy to update upon request with what would be wanted.

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
