### PR TITLE
Added flag reset to re-import `computer` instance

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -352,6 +352,7 @@ class OpenInterpreter:
 
     def reset(self):
         self.computer.terminate()  # Terminates all languages
+        self.computer._has_imported_computer_api = False  # Flag reset
         self.messages = []
         self.last_messages_count = 0
 


### PR DESCRIPTION
### Describe the changes you have made:
Reset the flag `computer._has_imported_computer_api` to False within the reset method of OpenInterpreter. 

### Reference any relevant issues (e.g. "Fixes #000"):
Closes #1166

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
