### PR TITLE
Fixed bug, may have broken something else but I don't think so

### DIFF
--- a/interpreter/core/computer/computer.py
+++ b/interpreter/core/computer/computer.py
@@ -49,6 +49,9 @@ class Computer:
         self.import_computer_api = False  # Defaults to false
         self._has_imported_computer_api = False  # Because we only want to do this once
 
+        self.should_import_skills = False
+        self._has_imported_skills = False
+
     # Shortcut for computer.terminal.languages
     @property
     def languages(self):

--- a/interpreter/core/computer/terminal/languages/jupyter_language.py
+++ b/interpreter/core/computer/terminal/languages/jupyter_language.py
@@ -26,16 +26,6 @@ class JupyterLanguage(BaseLanguage):
 
     def __init__(self, computer):
         self.computer = computer
-        # Filter out the following messages from IPKernelApp, to prevent the logs from showing up anytime someone presses CTRL+C
-        if not DEBUG_MODE:
-            ipkernel_logger = logging.getLogger('IPKernelApp')
-            # Create a filter using a lambda function
-            warning_filter = lambda record: not any(msg in record.getMessage() for msg in [
-                "Parent appears to have exited, shutting down.",
-                "Could not destroy zmq context"
-            ])
-            # Add the filter to the logger
-            ipkernel_logger.addFilter(warning_filter)
             
         self.km = KernelManager(kernel_name="python3")
         self.km.start_kernel()

--- a/interpreter/core/computer/terminal/terminal.py
+++ b/interpreter/core/computer/terminal/terminal.py
@@ -51,6 +51,13 @@ class Terminal:
                     display=self.computer.verbose,
                 )
 
+            if not self.computer._has_imported_skills:
+                self.computer._has_imported_skills = True
+                if self.computer.should_import_skills:
+                    if self.verbose:
+                        print("Importing skills")
+                    self.computer.skills.import_skills()
+
         if stream == False:
             # If stream == False, *pull* from _streaming_run.
             output_messages = []

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -123,10 +123,7 @@ class OpenInterpreter:
             self.computer.skills.path = skills_path
 
         self.import_skills = import_skills
-        if import_skills:
-            if self.verbose:
-                print("Importing skills")
-            self.computer.skills.import_skills()
+        self.computer.should_import_skills = import_skills
 
     def server(self, *args, **kwargs):
         server(self, *args, **kwargs)

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -437,3 +437,5 @@ def main():
         start_terminal_interface(interpreter)
     except KeyboardInterrupt:
         pass
+    finally:
+        interpreter.computer.terminate()

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -73,23 +73,16 @@ def terminal_interface(interpreter, message):
     voice_subprocess = None
 
     while True:
-        try:
-            if interactive:
-                ### This is the primary input for Open Interpreter.
-                message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
+        if interactive:
+            ### This is the primary input for Open Interpreter.
+            message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
 
-                try:
-                    # This lets users hit the up arrow key for past messages
-                    readline.add_history(message)
-                except:
-                    # If the user doesn't have readline (may be the case on windows), that's fine
-                    pass
-
-        except KeyboardInterrupt:
-            # Exit gracefully
-            # Disconnect from the computer interface
-            interpreter.computer.terminate()
-            break
+            try:
+                # This lets users hit the up arrow key for past messages
+                readline.add_history(message)
+            except:
+                # If the user doesn't have readline (may be the case on windows), that's fine
+                pass
 
         if isinstance(message, str):
             # This is for the terminal interface being used as a CLI — messages are strings.

--- a/scripts/ipkernel_warning_example.py
+++ b/scripts/ipkernel_warning_example.py
@@ -1,0 +1,17 @@
+from jupyter_client import KernelManager
+
+km1 = KernelManager()
+km1.start_kernel()
+
+kc1 = km1.client()
+kc1.start_channels()
+kc1.wait_for_ready()
+
+kc1.stop_channels()
+# If the following line is commented out, the message
+# "[IPKernelApp] WARNING | Parent appears to have exited, shutting down."
+# will appear after this script finishes running.
+km1.shutdown_kernel()
+
+del kc1
+del km1


### PR DESCRIPTION
### Problem fixed

Currently, holding `ctrl-c` to exit out of OpenInterpreter results in the string
`[IPKernelApp] WARNING | Parent appears to have exited, shutting down.`
printing to the console.

[This temporary script](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/scripts/ipkernel_warning_example.py) (that probably shouldn't be merged) illustrates why this happens.  Contributors can run the script by running the command `poetry run python scripts/ipkernel_warning_example.py`.
If this script is run without modification, the `IPKernelApp` warning is printed after the script exits.  Otherwise, if [this line](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/scripts/ipkernel_warning_example.py#L14) is commented out and then run, the `IPKernelApp` warning disappears.

The script shows that the warning occurs whenever a `KernelManager` fails to shutdown before its parent program (e.g. the OpenInterpreter terminal interface) exits.  Any solution to this problem therefore ensures that all `KernelManagers` are shutdown correctly.

### Changes made

The changes I made can be grouped into two categories:

1. Postponing skills import until right before code is run.
2. Fixed bug where the following string is printed at least once whenever OpenInterpreter is exited.
    - `[IPKernelApp] WARNING | Parent appears to have exited, shutting down.`

The first category of changes was necessary to remove the `[IPKernelApp]` warning resulting from the kernel started on [this line](https://github.com/OpenInterpreter/open-interpreter/blob/9c8a3b93e57dab0e4c6b0e9d39522158b7f70e43/interpreter/__init__.py#L4) in the `interpreter` module's [__init.py__](https://github.com/OpenInterpreter/open-interpreter/blob/9c8a3b93e57dab0e4c6b0e9d39522158b7f70e43/interpreter/__init__.py).

#### Postponing skills import

This change affects the following files:
- [computer.py](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/interpreter/core/computer/computer.py)
- [terminal.py](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/interpreter/core/computer/terminal/terminal.py)
- [core.py](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/interpreter/core/core.py)

#### Getting rid of `[IPKernelApp] Warning ...` log on exit

This change affects the following files:
- [jupyter_language.py](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/interpreter/core/computer/terminal/languages/jupyter_language.py)
- [start_terminal_interface.py](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/interpreter/terminal_interface/start_terminal_interface.py)
- [terminal_interface.py](https://github.com/imapersonman/open-interpreter/blob/8fb4668dc7451ac58ac57ba587ed77194469f739/interpreter/terminal_interface/terminal_interface.py)

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
