### PR TITLE
restored the default variable resulting is error when running OI

### DIFF
--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -259,6 +259,7 @@ def start_terminal_interface(interpreter):
     for arg in arguments:
         action = arg.get("action", "store_true")
         nickname = arg.get("nickname")
+        default = arg.get("default")
 
         name_or_flags = [f'--{arg["name"]}']
         if nickname:


### PR DESCRIPTION
### Describe the changes you have made:
restored the `default` variable resulting in an error when starting OI CLI due to its the removal in #1159 but it's still being used in https://github.com/OpenInterpreter/open-interpreter/blob/dbcc9e83c189a3721c109b713571567def4c700a/interpreter/terminal_interface/start_terminal_interface.py#L272-L290

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
