### PR TITLE
Fix default variable issue. 

### DIFF
--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -257,6 +257,7 @@ def start_terminal_interface(interpreter):
 
     # Add arguments
     for arg in arguments:
+        default = arg.get("default")
         action = arg.get("action", "store_true")
         nickname = arg.get("nickname")
 


### PR DESCRIPTION
### Describe the changes you have made:

idk when it happened, but something broke in the last few days, where 'default' is not defined. This prevents `poetry run interpreter` from running at all. Here is the error:

```
~/Documents/open-interpreter $ poetry run interpreter
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/tyfiero/Documents/open-interpreter/interpreter/terminal_interface/start_terminal_interface.py", line 442, in main
    start_terminal_interface(interpreter)
  File "/Users/tyfiero/Documents/open-interpreter/interpreter/terminal_interface/start_terminal_interface.py", line 288, in start_terminal_interface
    default=default,
            ^^^^^^^
```


I added back in `default = arg.get("default")` to fix this issue. 


### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
