### PR TITLE
Fix optional import crash and error

### DIFF
--- a/interpreter/core/computer/display/display.py
+++ b/interpreter/core/computer/display/display.py
@@ -12,7 +12,6 @@ from PIL import Image
 import requests
 from ...utils.lazy_import import lazy_import
 from ..utils.recipient_utils import format_to_recipient
-import cv2
 from screeninfo import get_monitors # for getting info about connected monitors
 
 
@@ -20,6 +19,7 @@ from screeninfo import get_monitors # for getting info about connected monitors
 # from utils.get_active_window import get_active_window
 
 # Lazy import of optional packages
+cv2 = lazy_import("cv2")
 pyautogui = lazy_import("pyautogui")
 np = lazy_import("numpy")
 plt = lazy_import("matplotlib.pyplot")

--- a/interpreter/terminal_interface/profiles/defaults/01.py
+++ b/interpreter/terminal_interface/profiles/defaults/01.py
@@ -216,7 +216,7 @@ if missing_packages:
         print("Attempting to start OS control anyway...\n\n")
 
     for pip_name in ["pip", "pip3"]:
-        command = f"{pip_name} install 'open-interpreter[os]'"
+        command = f"{pip_name} install open-interpreter[os]"
 
         interpreter.computer.run("shell", command, display=True)
 

--- a/interpreter/terminal_interface/profiles/defaults/os.py
+++ b/interpreter/terminal_interface/profiles/defaults/os.py
@@ -170,7 +170,7 @@ if missing_packages:
         print("Attempting to start OS control anyway...\n\n")
 
     for pip_name in ["pip", "pip3"]:
-        command = f"{pip_name} install 'open-interpreter[os]'"
+        command = f"{pip_name} install open-interpreter[os]"
 
         interpreter.computer.run("shell", command, display=True)
 


### PR DESCRIPTION
### Describe the changes you have made:
- Fixed a crash by converting a missed import cv2 in display.py to lazy_import.
- Removed the single quotes around pip install open-interpreter[os].

### Reference any relevant issues (e.g. "Fixes #000"):
- ModuleNotFoundError: No module named 'cv2'
- ERROR: Invalid requirement: "'open-interpreter[os]'"

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
