### PR TITLE
Fix Llama3 backtick hallucination in code blocks

### DIFF
--- a/interpreter/core/computer/terminal/terminal.py
+++ b/interpreter/core/computer/terminal/terminal.py
@@ -51,6 +51,10 @@ class Terminal:
                 self.computer._has_imported_skills = True
                 self.computer.skills.import_skills()
 
+        # Llama 3 likes to hallucinate this tick new line thing at the start of code blocks
+        if code.startswith("`\n"):
+            code = code[2:].strip()
+
         if stream == False:
             # If stream == False, *pull* from _streaming_run.
             output_messages = []


### PR DESCRIPTION
### Describe the changes you have made:
Fixed a common hallucination of Llama3 inserting a backtick at the start of a code block.

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1228
```
  `
  print("Hello, World!")
```
  Cell In[6], line 1
      `
      ^
  SyntaxError: invalid syntax

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
