### PR TITLE
Added batch, bat aliases for shell language

### DIFF
--- a/interpreter/core/computer/terminal/languages/shell.py
+++ b/interpreter/core/computer/terminal/languages/shell.py
@@ -8,7 +8,7 @@ from .subprocess_language import SubprocessLanguage
 class Shell(SubprocessLanguage):
     file_extension = "sh"
     name = "Shell"
-    aliases = ["bash", "sh", "zsh"]
+    aliases = ["bash", "sh", "zsh", "batch", "bat"]
 
     def __init__(
         self,


### PR DESCRIPTION
### Describe the changes you have made:
- Added aliases 'batch' and 'bat' to the shell language to match the linux/mac aliases.

### Reference any relevant issues (e.g. "Fixes #000"):
- Handles the case when local models try to run 'batch' instead of 'shell' on Windows.
- Partially related to: https://github.com/OpenInterpreter/open-interpreter/issues/1231#issuecomment-2073577430

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
