### PR TITLE
Auto continue

### DIFF
--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -458,6 +458,26 @@ auto_run: true
 
 </CodeGroup>
 
+### Auto Continue
+
+Automatically tell interpreter to "continue" until CTRL+C is pressed.
+
+<CodeGroup>
+
+```bash Terminal
+interpreter --auto_continue
+```
+
+```python Python
+interpreter.auto_continue = True
+```
+
+```yaml Profile
+auto_continue: true
+```
+
+</CodeGroup>
+
 ### Max Budget
 
 Sets the maximum budget limit for the session in USD.

--- a/docs/usage/python/arguments.mdx
+++ b/docs/usage/python/arguments.mdx
@@ -75,6 +75,20 @@ interpreter.auto_run = False  # Require user confirmation (default)
 
 ---
 
+
+---
+
+#### `auto_continue`
+
+Setting this flag to `True` will reply with the word "continue" to Open Interpreter whenever input option is given to user. Break out of this with CTRL+C
+
+```python
+interpreter.auto_continue = True  
+interpreter.auto_continue = False
+```
+
+---
+
 #### `verbose`
 
 Use this boolean flag to toggle verbose mode on or off. Verbose mode will print information at every step to help diagnose problems.

--- a/docs/usage/terminal/arguments.mdx
+++ b/docs/usage/terminal/arguments.mdx
@@ -16,7 +16,7 @@ title: Arguments
 
 **[Options](/docs/usage/terminal/arguments#options)**
 
-`--safe_mode`, `--auto_run`, `--force_task_completion`, `--verbose`, `--max_budget`, `--speak_messages`, `--multi_line`.
+`--safe_mode`, `--auto_run`, `--auto_continue`, `--force_task_completion`, `--verbose`, `--max_budget`, `--speak_messages`, `--multi_line`.
 
 **[Other](/docs/usage/terminal/arguments#other)**
 
@@ -337,6 +337,26 @@ interpreter --auto_run
 
 ```yaml Config
 auto_run: true
+```
+
+</CodeGroup>
+
+### `--auto_continue` or `-ac`
+
+Automatically tell interpreter to "continue" until CTRL+C is pressed.
+
+<CodeGroup>
+
+```bash Terminal
+interpreter --auto_continue
+```
+
+```python Python
+interpreter.auto_continue = True
+```
+
+```yaml Profile
+auto_continue: true
 ```
 
 </CodeGroup>

--- a/docs/usage/terminal/settings.mdx
+++ b/docs/usage/terminal/settings.mdx
@@ -23,4 +23,5 @@ interpreter --profiles
 | `offline`                | Boolean [True/False]                                     |
 | `vision`                 | Boolean [True/False]                                     |
 | `auto_run`               | Boolean [True/False]                                     |
+| `auto_continue`          | Boolean [True/False]                                     |
 | `verbose`                | Boolean [True/False]                                     |

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -44,6 +44,7 @@ class OpenInterpreter:
         messages=None,
         offline=False,
         auto_run=False,
+        auto_continue=False,
         verbose=False,
         debug=False,
         max_output=2800,
@@ -83,6 +84,7 @@ class OpenInterpreter:
         # Settings
         self.offline = offline
         self.auto_run = auto_run
+        self.auto_continue = auto_continue
         self.verbose = verbose
         self.debug = debug
         self.max_output = max_output

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -49,6 +49,13 @@ def start_terminal_interface(interpreter):
             "attribute": {"object": interpreter, "attr_name": "auto_run"},
         },
         {
+            "name": "auto_continue",
+            "nickname": "ac",
+            "help_text": "automatically tell the agent to continue after every response",
+            "type": bool,
+            "attribute": {"object": interpreter, "attr_name": "auto_continue"},
+        },
+        {
             "name": "verbose",
             "nickname": "v",
             "help_text": "print detailed logs",

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -71,11 +71,16 @@ def terminal_interface(interpreter, message):
 
     active_block = None
     voice_subprocess = None
+    auto_continue_initiated = False
 
     while True:
         if interactive:
-            ### This is the primary input for Open Interpreter.
-            message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
+            if interpreter.auto_continue and auto_continue_initiated:
+                message = "continue"
+            else:
+                ### This is the primary input for Open Interpreter.
+                message = cli_input("> ").strip() if interpreter.multi_line else input("> ").strip()
+                auto_continue_initiated = True
 
             try:
                 # This lets users hit the up arrow key for past messages
@@ -425,6 +430,10 @@ def terminal_interface(interpreter, message):
                 break
 
         except KeyboardInterrupt:
+            print("@@@INTERUPT DETECTED!@@@@")
+            if auto_continue_initiated:
+                auto_continue_initiated = False
+            
             # Exit gracefully
             if "active_block" in locals() and active_block:
                 active_block.end()

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -75,7 +75,9 @@ def terminal_interface(interpreter, message):
 
     while True:
         if interactive:
+        
             if interpreter.auto_continue and auto_continue_initiated:
+                ## This sends 'continue' prompt back to LLM if auto_continue flag is True
                 message = "continue"
             else:
                 ### This is the primary input for Open Interpreter.
@@ -430,7 +432,7 @@ def terminal_interface(interpreter, message):
                 break
 
         except KeyboardInterrupt:
-            print("@@@INTERUPT DETECTED!@@@@")
+            #Reset auto_continue variable to enable user to input again
             if auto_continue_initiated:
                 auto_continue_initiated = False
             


### PR DESCRIPTION
### Describe the changes you have made:

Added a flag `auto_continue` which sends back prompt "Continue" to LLM automatically after conversation has initiated.
This is very useful for 7B models as they tell you what they are going to do without doing it, so usually a lot of manual 'continue' prompting is required. 

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ Y ] I have included relevant documentation updates (stored in /docs)
- [ Y ] I have read `docs/CONTRIBUTING.md`
- [ Y ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ Y ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
