### PR TITLE
New Terminal Option: `--no_live_response`

### DIFF
--- a/docs/usage/terminal/arguments.mdx
+++ b/docs/usage/terminal/arguments.mdx
@@ -16,7 +16,7 @@ title: Arguments
 
 **[Options](/docs/usage/terminal/arguments#options)**
 
-`--safe_mode`, `--auto_run`, `--force_task_completion`, `--verbose`, `--max_budget`, `--speak_messages`, `--multi_line`.
+`--safe_mode`, `--auto_run`, `--force_task_completion`, `--verbose`, `--max_budget`, `--speak_messages`, `--multi_line`, `--no_live_response`.
 
 **[Other](/docs/usage/terminal/arguments#other)**
 
@@ -414,6 +414,21 @@ interpreter --multi_line
 
 ```yaml Config
 multi_line: true
+```
+
+</CodeGroup>
+
+#### `--no_live_response`
+
+Perform a one-time rendering after the whole response was finished instead of live rending while receiving response chunks, this will prevent showing duplicate lines in terminal and reduce bandwidth usage and twinkling when using via SSH
+
+<CodeGroup>
+```bash Terminal
+interpreter --no_live_response
+```
+
+```yaml Config
+no_live_response: true
 ```
 
 </CodeGroup>

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -78,6 +78,7 @@ class OpenInterpreter:
         import_skills=False,
         multi_line=False,
         contribute_conversation=False,
+        no_live_response=False,
     ):
         # State
         self.messages = [] if messages is None else messages
@@ -96,6 +97,7 @@ class OpenInterpreter:
         self.in_terminal_interface = in_terminal_interface
         self.multi_line = multi_line
         self.contribute_conversation = contribute_conversation
+        self.no_live_response = no_live_response
 
         # Loop messages
         self.force_task_completion = force_task_completion

--- a/interpreter/terminal_interface/components/base_block.py
+++ b/interpreter/terminal_interface/components/base_block.py
@@ -1,5 +1,6 @@
 from rich.console import Console
 from rich.live import Live
+from rich.spinner import Spinner
 
 
 class BaseBlock:
@@ -12,13 +13,14 @@ class BaseBlock:
             auto_refresh=False, console=Console(), vertical_overflow="visible"
         )
         self.live.start()
+        self.spinner = Spinner(name="dots", text="Generating responses...")
 
     def update_from_message(self, message):
         raise NotImplementedError("Subclasses must implement this method")
 
     def end(self):
-        self.refresh(cursor=False)
+        self.refresh(cursor=False, end=True)
         self.live.stop()
 
-    def refresh(self, cursor=True):
+    def refresh(self, cursor=True, end=False):
         raise NotImplementedError("Subclasses must implement this method")

--- a/interpreter/terminal_interface/components/base_block.py
+++ b/interpreter/terminal_interface/components/base_block.py
@@ -9,12 +9,13 @@ class BaseBlock:
     a visual "block" on the terminal.
     """
 
-    def __init__(self):
+    def __init__(self, no_live_response: bool = False):
         self.live = Live(
             auto_refresh=False, console=Console(), vertical_overflow="visible"
         )
         self.live.start()
         self.spinner = OISpinner()
+        self.no_live_response = no_live_response
 
     def update_from_message(self, message):
         raise NotImplementedError("Subclasses must implement this method")

--- a/interpreter/terminal_interface/components/base_block.py
+++ b/interpreter/terminal_interface/components/base_block.py
@@ -1,6 +1,7 @@
 from rich.console import Console
 from rich.live import Live
-from rich.spinner import Spinner
+
+from .spinner import OISpinner
 
 
 class BaseBlock:
@@ -13,7 +14,7 @@ class BaseBlock:
             auto_refresh=False, console=Console(), vertical_overflow="visible"
         )
         self.live.start()
-        self.spinner = Spinner(name="dots", text="Generating responses...")
+        self.spinner = OISpinner()
 
     def update_from_message(self, message):
         raise NotImplementedError("Subclasses must implement this method")

--- a/interpreter/terminal_interface/components/code_block.py
+++ b/interpreter/terminal_interface/components/code_block.py
@@ -26,62 +26,67 @@ class CodeBlock(BaseBlock):
 
     def end(self):
         self.active_line = None
-        self.refresh(cursor=False)
+        self.refresh(cursor=False, end=True)
         super().end()
 
-    def refresh(self, cursor=True):
+    def refresh(self, cursor=True, end=False):
         if not self.code and not self.output:
             return
 
-        # Get code
-        code = self.code
-
-        # Create a table for the code
-        code_table = Table(
-            show_header=False, show_footer=False, box=None, padding=0, expand=True
-        )
-        code_table.add_column()
-
-        # Add cursor
-        if cursor:
-            code += "●"
-
-        # Add each line of code to the table
-        code_lines = code.strip().split("\n")
-        for i, line in enumerate(code_lines, start=1):
-            if i == self.active_line:
-                # This is the active line, print it with a white background
-                syntax = Syntax(
-                    line, self.language, theme="bw", line_numbers=False, word_wrap=True
-                )
-                code_table.add_row(syntax, style="black on white")
-            else:
-                # This is not the active line, print it normally
-                syntax = Syntax(
-                    line,
-                    self.language,
-                    theme="monokai",
-                    line_numbers=False,
-                    word_wrap=True,
-                )
-                code_table.add_row(syntax)
-
-        # Create a panel for the code
-        code_panel = Panel(code_table, box=MINIMAL, style="on #272722")
-
-        # Create a panel for the output (if there is any)
-        if self.output == "" or self.output == "None":
-            output_panel = ""
+        # TODO: and live_refresh was turned off
+        if not end:
+            self.live.update(self.spinner)
+            self.live.refresh()
         else:
-            output_panel = Panel(self.output, box=MINIMAL, style="#FFFFFF on #3b3b37")
+            # Get code
+            code = self.code
 
-        # Create a group with the code table and output panel
-        group_items = [code_panel, output_panel]
-        if self.margin_top:
-            # This adds some space at the top. Just looks good!
-            group_items = [""] + group_items
-        group = Group(*group_items)
+            # Create a table for the code
+            code_table = Table(
+                show_header=False, show_footer=False, box=None, padding=0, expand=True
+            )
+            code_table.add_column()
 
-        # Update the live display
-        self.live.update(group)
-        self.live.refresh()
+            # Add cursor
+            if cursor:
+                code += "●"
+
+            # Add each line of code to the table
+            code_lines = code.strip().split("\n")
+            for i, line in enumerate(code_lines, start=1):
+                if i == self.active_line:
+                    # This is the active line, print it with a white background
+                    syntax = Syntax(
+                        line, self.language, theme="bw", line_numbers=False, word_wrap=True
+                    )
+                    code_table.add_row(syntax, style="black on white")
+                else:
+                    # This is not the active line, print it normally
+                    syntax = Syntax(
+                        line,
+                        self.language,
+                        theme="monokai",
+                        line_numbers=False,
+                        word_wrap=True,
+                    )
+                    code_table.add_row(syntax)
+
+            # Create a panel for the code
+            code_panel = Panel(code_table, box=MINIMAL, style="on #272722")
+
+            # Create a panel for the output (if there is any)
+            if self.output == "" or self.output == "None":
+                output_panel = ""
+            else:
+                output_panel = Panel(self.output, box=MINIMAL, style="#FFFFFF on #3b3b37")
+
+            # Create a group with the code table and output panel
+            group_items = [code_panel, output_panel]
+            if self.margin_top:
+                # This adds some space at the top. Just looks good!
+                group_items = [""] + group_items
+            group = Group(*group_items)
+
+            # Update the live display
+            self.live.update(group)
+            self.live.refresh()

--- a/interpreter/terminal_interface/components/code_block.py
+++ b/interpreter/terminal_interface/components/code_block.py
@@ -12,8 +12,8 @@ class CodeBlock(BaseBlock):
     Code Blocks display code and outputs in different languages. You can also set the active_line!
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, no_live_response: bool = False):
+        super().__init__(no_live_response)
 
         self.type = "code"
 
@@ -33,8 +33,7 @@ class CodeBlock(BaseBlock):
         if not self.code and not self.output:
             return
 
-        # TODO: and live_refresh was turned off
-        if not end:
+        if not end and self.no_live_response:
             self.live.update(self.spinner)
             self.live.refresh()
         else:

--- a/interpreter/terminal_interface/components/message_block.py
+++ b/interpreter/terminal_interface/components/message_block.py
@@ -14,18 +14,23 @@ class MessageBlock(BaseBlock):
         self.type = "message"
         self.message = ""
 
-    def refresh(self, cursor=True):
-        # De-stylize any code blocks in markdown,
-        # to differentiate from our Code Blocks
-        content = textify_markdown_code_blocks(self.message)
+    def refresh(self, cursor=True, end=False):
+        # TODO: and live_refresh was turned off
+        if not end:
+            self.live.update(self.spinner)
+            self.live.refresh()
+        else:
+            # De-stylize any code blocks in markdown,
+            # to differentiate from our Code Blocks
+            content = textify_markdown_code_blocks(self.message)
 
-        if cursor:
-            content += "●"
+            if cursor:
+                content += "●"
 
-        markdown = Markdown(content.strip())
-        panel = Panel(markdown, box=MINIMAL)
-        self.live.update(panel)
-        self.live.refresh()
+            markdown = Markdown(content.strip())
+            panel = Panel(markdown, box=MINIMAL)
+            self.live.update(panel)
+            self.live.refresh()
 
 
 def textify_markdown_code_blocks(text):

--- a/interpreter/terminal_interface/components/message_block.py
+++ b/interpreter/terminal_interface/components/message_block.py
@@ -8,15 +8,14 @@ from .base_block import BaseBlock
 
 
 class MessageBlock(BaseBlock):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, no_live_response: bool = False):
+        super().__init__(no_live_response)
 
         self.type = "message"
         self.message = ""
 
     def refresh(self, cursor=True, end=False):
-        # TODO: and live_refresh was turned off
-        if not end:
+        if not end and self.no_live_response:
             self.live.update(self.spinner)
             self.live.refresh()
         else:

--- a/interpreter/terminal_interface/components/spinner.py
+++ b/interpreter/terminal_interface/components/spinner.py
@@ -1,0 +1,7 @@
+from rich.spinner import Spinner
+
+
+class OISpinner(Spinner):
+    def __init__(self):
+        super().__init__(name="dots", text="Generating responses...")
+        self.frames = ["●", "•"]

--- a/interpreter/terminal_interface/profiles/defaults/default.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/default.yaml
@@ -20,6 +20,7 @@ llm:
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
+# no_live_response: False # If True, it will perform a one-time rendering after the whole response was finished instead of live rending while receiving response chunks, this will prevent showing duplicate lines in terminal and reduce bandwidth usage and twinkling when using via SSH
 
 # Documentation
 # All options: https://docs.openinterpreter.com/settings

--- a/interpreter/terminal_interface/profiles/defaults/fast.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/fast.yaml
@@ -16,6 +16,7 @@ custom_instructions: "The user has set you to FAST mode. **No talk, just code.**
 # offline: False  # If True, will disable some online features like checking for updates
 # verbose: False  # If True, will print detailed logs
 # multi_line: False # If True, you can input multiple lines starting and ending with ```
+# no_live_response: False # If True, it will perform a one-time rendering after the whole response was finished instead of live rending while receiving response chunks, this will prevent showing duplicate lines in terminal and reduce bandwidth usage and twinkling when using via SSH
 
 # All options: https://docs.openinterpreter.com/settings
 

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -244,7 +244,13 @@ def start_terminal_interface(interpreter):
             "help_text": "let Open Interpreter use the current conversation to train an Open-Source LLM",
             "type": bool,
             "attribute": {"object": interpreter, "attr_name": "contribute_conversation"},
-        }
+        },
+        {
+            "name": "no_live_response",
+            "help_text": "perform a one-time rendering after the whole response was finished instead of live rending while receiving response chunks",
+            "type": bool,
+            "attribute": {"object": interpreter, "attr_name": "no_live_response"},
+        },
     ]
 
     # Check for deprecated flags before parsing arguments
@@ -430,7 +436,7 @@ def start_terminal_interface(interpreter):
     if args.server:
         interpreter.server()
         return
-    
+
     validate_llm_settings(interpreter)
 
     interpreter.in_terminal_interface = True

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -163,7 +163,7 @@ def terminal_interface(interpreter, message):
                 # Assistant message blocks
                 if chunk["type"] == "message":
                     if "start" in chunk:
-                        active_block = MessageBlock()
+                        active_block = MessageBlock(no_live_response=interpreter.no_live_response)
                         render_cursor = True
 
                     if "content" in chunk:
@@ -215,7 +215,7 @@ def terminal_interface(interpreter, message):
                 # Assistant code blocks
                 elif chunk["role"] == "assistant" and chunk["type"] == "code":
                     if "start" in chunk:
-                        active_block = CodeBlock()
+                        active_block = CodeBlock(no_live_response=interpreter.no_live_response)
                         active_block.language = chunk["format"]
                         render_cursor = True
 
@@ -262,7 +262,7 @@ def terminal_interface(interpreter, message):
                         if response.strip().lower() == "y":
                             # Create a new, identical block where the code will actually be run
                             # Conveniently, the chunk includes everything we need to do this:
-                            active_block = CodeBlock()
+                            active_block = CodeBlock(no_live_response=interpreter.no_live_response)
                             active_block.margin_top = False  # <- Aesthetic choice
                             active_block.language = language
                             active_block.code = code
@@ -408,7 +408,7 @@ def terminal_interface(interpreter, message):
                         if not isinstance(active_block, CodeBlock):
                             if active_block:
                                 active_block.end()
-                            active_block = CodeBlock()
+                            active_block = CodeBlock(no_live_response=interpreter.no_live_response)
 
                 if active_block:
                     active_block.refresh(cursor=render_cursor)


### PR DESCRIPTION
### Describe the changes you have made:
Add a new terminal option which allows users to config whether rendering responses while receiving chunks (classic and default behavior) or perform a one-time rendering after all chunks were received (new behavior).

Perform a one-time rendering after all chunks were received will prevent showing duplicate lines in terminal and especially when using via SSH it will reduce bandwidth usage and twinkling.

### Reference any relevant issues (e.g. "Fixes #000"):
Temporally fixes #1127

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
