### PR TITLE
Update multiple-instances.mdx with correct key/value pairs for message dicts

### DIFF
--- a/docs/usage/python/multiple-instances.mdx
+++ b/docs/usage/python/multiple-instances.mdx
@@ -24,7 +24,7 @@ def swap_roles(messages):
 agents = [agent_1, agent_2]
 
 # Kick off the conversation
-messages = [{"role": "user", "message": "Hello!"}]
+messages = [{"role": "user", "type": "message", "content": "Hello!"}]
 
 while True:
     for agent in agents:


### PR DESCRIPTION
### Describe the changes you have made:
The example for multiple instances does not currently work since core.py expects the message input to contain the keys:

* type
* content

### Reference any relevant issues (e.g. "Fixes #000"):
N/A

### Pre-Submission Checklist (optional but appreciated):

- [ N/A] I have included relevant documentation updates (stored in /docs)
- [ X ] I have read `docs/CONTRIBUTING.md`
- [ X] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
