### PR TITLE
re: remove redundant new line char for the tip

### DIFF
--- a/interpreter/terminal_interface/validate_llm_settings.py
+++ b/interpreter/terminal_interface/validate_llm_settings.py
@@ -72,8 +72,8 @@ def validate_llm_settings(interpreter):
                         """
 
                     **Tip:** To save this key for later, run one of the following and then restart your terminal. 
-                    MacOS: `echo '\\nexport OPENAI_API_KEY=your_api_key' >> ~/.zshrc`
-                    Linux: `echo '\\nexport OPENAI_API_KEY=your_api_key' >> ~/.bashrc`
+                    MacOS: `echo 'export OPENAI_API_KEY=your_api_key' >> ~/.zshrc`
+                    Linux: `echo 'export OPENAI_API_KEY=your_api_key' >> ~/.bashrc`
                     Windows: `setx OPENAI_API_KEY your_api_key`
                     
                     ---"""


### PR DESCRIPTION
### Describe the changes you have made:

Removed the redundant new line character in the tip mentioned.

### Reference any relevant issues (e.g. "Fixes #000"): 
Fixes #1338 

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
