### PR TITLE
feat: let people turn of active highlighting

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@
 - [ ] Figure out how to get OI to answer to user input requests like python's `input()`. Do we somehow detect a delay in the output..? Is there some universal flag that TUIs emit when they expect user input? Should we do this semantically with embeddings, then ask OI to review it and respond..?
 - [ ] Placeholder text that gives a compelling example OI request. Probably use `textual`
 - [ ] Everything else `textual` offers, like could we make it easier to select text? Copy paste in and out? Code editing interface?
-- [ ] Let people turn off the active line highlighting
+- [x] Let people turn off the active line highlighting
 - [ ] Add a --plain flag which doesn't use rich, just prints stuff in plain text
 - [ ] Use iPython stuff to track the active line, instead of inserting print statements, which makes debugging weird (From ChatGPT: For deeper insights into what's happening behind the scenes, including which line of code is being executed, you can increase the logging level of the IPython kernel. You can configure the kernel's logger to a more verbose setting, which logs each execution request. However, this requires modifying the kernel's startup settings, which might involve changing logging configurations in the IPython kernel source or when launching the kernel.)
 - [ ] Let people edit the code OI writes. Could just open it in the user's preferred editor. Simple. [Full description of how to implement this here.](https://github.com/KillianLucas/open-interpreter/pull/830#issuecomment-1854989795)

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -99,6 +99,7 @@ class OpenInterpreter:
         self.multi_line = multi_line
         self.contribute_conversation = contribute_conversation
         self.plain_text_display = plain_text_display
+        self.highlight_active_line = True  # additional setting to toggle active line highlighting. Defaults to True
 
         # Loop messages
         self.loop = loop

--- a/interpreter/terminal_interface/components/code_block.py
+++ b/interpreter/terminal_interface/components/code_block.py
@@ -12,10 +12,13 @@ class CodeBlock(BaseBlock):
     Code Blocks display code and outputs in different languages. You can also set the active_line!
     """
 
-    def __init__(self):
+    def __init__(self, interpreter=None):
         super().__init__()
 
         self.type = "code"
+        self.highlight_active_line = (
+            interpreter.highlight_active_line if interpreter else None
+        )
 
         # Define these for IDE auto-completion
         self.language = ""
@@ -42,14 +45,22 @@ class CodeBlock(BaseBlock):
         )
         code_table.add_column()
 
-        # Add cursor
-        if cursor:
+        # Add cursor only if active line highliting is true
+        if cursor and (
+            self.highlight_active_line
+            if self.highlight_active_line is not None
+            else True
+        ):
             code += "●"
 
         # Add each line of code to the table
         code_lines = code.strip().split("\n")
         for i, line in enumerate(code_lines, start=1):
-            if i == self.active_line:
+            if i == self.active_line and (
+                self.highlight_active_line
+                if self.highlight_active_line is not None
+                else True
+            ):
                 # This is the active line, print it with a white background
                 syntax = Syntax(
                     line, self.language, theme="bw", line_numbers=False, word_wrap=True

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -51,6 +51,14 @@ def start_terminal_interface(interpreter):
             "attribute": {"object": interpreter, "attr_name": "auto_run"},
         },
         {
+            "name": "no_highlight_active_line",
+            "nickname": "nhl",
+            "help_text": "turn off active line highlighting in code blocks",
+            "type": bool,
+            "action": "store_true",
+            "default": False,  # Default to False, meaning highlighting is on by default
+        },
+        {
             "name": "verbose",
             "nickname": "v",
             "help_text": "print detailed logs",
@@ -380,6 +388,9 @@ Use """ to write multi-line messages.
         update_name = "Local III"  # Change this with each major update
         print(f"Open Interpreter {version} {update_name}")
         return
+
+    if args.no_highlight_active_line:
+        interpreter.highlight_active_line = False
 
     # if safe_mode and auto_run are enabled, safe_mode disables auto_run
     if interpreter.auto_run and (

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -221,7 +221,7 @@ def terminal_interface(interpreter, message):
                         if response.strip().lower() == "y":
                             # Create a new, identical block where the code will actually be run
                             # Conveniently, the chunk includes everything we need to do this:
-                            active_block = CodeBlock()
+                            active_block = CodeBlock(interpreter)
                             active_block.margin_top = False  # <- Aesthetic choice
                             active_block.language = language
                             active_block.code = code


### PR DESCRIPTION
### Describe the changes you have made:
- Added a new feature to allow users to turn off active line highlighting in code blocks
- Implemented a new CLI argument `--no-highlight-active-line` (short form: `-nhl`) to disable active line highlighting
- Modified the `OpenInterpreter` class to include a `highlight_active_line` attribute
- Updated the `CodeBlock` class to respect the `highlight_active_line` setting
- Adjusted the `terminal_interface` function to pass the interpreter instance to `CodeBlock`
- Updated the `ROADMAP.md` to mark the "Let people turn off the active line highlighting" task as completed

### Pre-Submission Checklist (optional but appreciated):
- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):
- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux

### Additional Notes:
This PR adds the ability for users to disable active line highlighting in code blocks, which can be useful for users who prefer a cleaner output or for scenarios where the highlighting might interfere with readability. The feature is disabled by default, maintaining the current behavior, but can be turned off using the new CLI argument.

Please review the changes and let me know if any further modifications or testing are needed.