### PR TITLE
Added Groq profile and flag

### DIFF
--- a/interpreter/terminal_interface/profiles/defaults/groq.py
+++ b/interpreter/terminal_interface/profiles/defaults/groq.py
@@ -1,0 +1,16 @@
+"""
+This is an Open Interpreter profile. It configures Open Interpreter to run `Llama 3.1 70B` using Groq.
+
+Make sure to set GROQ_API_KEY environment variable to your API key.
+"""
+
+from interpreter import interpreter
+
+interpreter.llm.model = "groq/llama-3.1-70b-versatile"
+
+interpreter.computer.import_computer_api = True
+
+interpreter.llm.supports_functions = False
+interpreter.llm.supports_vision = False
+interpreter.llm.context_window = 110000
+interpreter.llm.max_tokens = 4096

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -223,6 +223,11 @@ def start_terminal_interface(interpreter):
             "type": bool,
         },
         {
+            "name": "groq",
+            "help_text": "shortcut for `interpreter --profile groq`",
+            "type": bool,
+        },
+        {
             "name": "vision",
             "nickname": "vi",
             "help_text": "experimentally use vision for supported languages (shortcut for `interpreter --profile vision`)",
@@ -439,6 +444,9 @@ Use """ to write multi-line messages.
             args.profile = "llama3-vision.py"
         if args.os:
             args.profile = "llama3-os.py"
+
+    if args.groq:
+        args.profile = "groq.py"
 
     interpreter = profile(
         interpreter,


### PR DESCRIPTION
Added Open Interpreter `groq` profile support via default `groq.py` file, updated parser for CLI shortcut in `start_terminal_interface.py` to accept `--groq` flag to apply the profile
### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
