### PR TITLE
Hide missing cost completion map warnings LiteLLM

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -25,6 +25,17 @@ from .run_text_llm import run_text_llm
 from .run_tool_calling_llm import run_tool_calling_llm
 from .utils.convert_to_openai_messages import convert_to_openai_messages
 
+import logging
+
+# Create or get the logger
+logger = logging.getLogger('LiteLLM')
+
+class SuppressDebugFilter(logging.Filter):
+    def filter(self, record):
+        # Suppress only the specific message containing the keywords
+        if "cost map" in record.getMessage():
+            return False  # Suppress this log message
+        return True  # Allow all other messages
 
 class Llm:
     """
@@ -32,6 +43,9 @@ class Llm:
     """
 
     def __init__(self, interpreter):
+        # Add the filter to the logger
+        logger.addFilter(SuppressDebugFilter())
+
         # Store a reference to parent interpreter
         self.interpreter = interpreter
 


### PR DESCRIPTION
### Describe the changes you have made:
- Hides the wall of warnings LiteLLM gives if you use a model that isn't added to their cost completion map yet.

### Reference any relevant issues (e.g. "Fixes #000"):
- Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1408

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
