### PR TITLE
Updated fast mode to gpt-4o-mini & Profile version updated

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -54,7 +54,7 @@ class Llm:
         self.completions = fixed_litellm_completions
 
         # Settings
-        self.model = "gpt-4-turbo"
+        self.model = "gpt-4o"
         self.temperature = 0
 
         self.supports_vision = None  # Will try to auto-detect

--- a/interpreter/terminal_interface/profiles/defaults/default.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/default.yaml
@@ -4,7 +4,7 @@
 
 # LLM Settings
 llm:
-  model: "gpt-4-turbo"
+  model: "gpt-4o"
   temperature: 0
   # api_key: ...  # Your API key, if the API requires it
   # api_base: ...  # The URL where an OpenAI-compatible server is running to handle LLM API requests
@@ -26,7 +26,7 @@ computer:
 
 # To use a separate model for the `wtf` command:
 # wtf:
-#   model: "gpt-3.5-turbo"
+#   model: "gpt-4o-mini"
 
 # Documentation
 # All options: https://docs.openinterpreter.com/settings

--- a/interpreter/terminal_interface/profiles/defaults/fast.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/fast.yaml
@@ -3,7 +3,7 @@
 # Remove the "#" before the settings below to use them.
 
 llm:
-  model: "gpt-3.5-turbo"
+  model: "gpt-4o-mini"
   temperature: 0
   # api_key: ...  # Your API key, if the API requires it
   # api_base: ...  # The URL where an OpenAI-compatible server is running to handle LLM API requests

--- a/interpreter/terminal_interface/profiles/defaults/fast.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/fast.yaml
@@ -23,4 +23,4 @@ custom_instructions: "The user has set you to FAST mode. **No talk, just code.**
 
 # All options: https://docs.openinterpreter.com/settings
 
-version: 0.2.1 # Configuration file version (do not modify)
+version: 0.2.5 # Configuration file version (do not modify)

--- a/interpreter/terminal_interface/profiles/defaults/snowpark.yml
+++ b/interpreter/terminal_interface/profiles/defaults/snowpark.yml
@@ -4,7 +4,7 @@
 
 # LLM Settings
 llm:
-  model: "gpt-4-turbo"
+  model: "gpt-4o"
   temperature: 0
   # api_key: ...  # Your API key, if the API requires it
   # api_base: ...  # The URL where an OpenAI-compatible server is running to handle LLM API requests

--- a/interpreter/terminal_interface/profiles/defaults/vision.yaml
+++ b/interpreter/terminal_interface/profiles/defaults/vision.yaml
@@ -17,5 +17,5 @@ llm:
 
 # All options: https://docs.openinterpreter.com/usage/terminal/settings
 
-version: 0.2.1 # Configuration file version (do not modify)
+version: 0.2.5 # Configuration file version (do not modify)
 

--- a/interpreter/terminal_interface/profiles/profiles.py
+++ b/interpreter/terminal_interface/profiles/profiles.py
@@ -171,11 +171,11 @@ def apply_profile(interpreter, profile, profile_path):
 
                 try:
                     if profile["llm"]["model"] == "gpt-4":
-                        text = text.replace("gpt-4", "gpt-4-turbo")
-                        profile["llm"]["model"] = "gpt-4-turbo"
+                        text = text.replace("gpt-4", "gpt-4o")
+                        profile["llm"]["model"] = "gpt-4o"
                     elif profile["llm"]["model"] == "gpt-4-turbo-preview":
-                        text = text.replace("gpt-4-turbo-preview", "gpt-4-turbo")
-                        profile["llm"]["model"] = "gpt-4-turbo"
+                        text = text.replace("gpt-4-turbo-preview", "gpt-4o")
+                        profile["llm"]["model"] = "gpt-4o"
                 except:
                     raise
                     pass  # fine

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -198,7 +198,7 @@ def start_terminal_interface(interpreter):
         {
             "name": "fast",
             "nickname": "f",
-            "help_text": "runs `interpreter --model gpt-3.5-turbo` and asks OI to be extremely concise (shortcut for `interpreter --profile fast`)",
+            "help_text": "runs `interpreter --model gpt-4o-mini` and asks OI to be extremely concise (shortcut for `interpreter --profile fast`)",
             "type": bool,
         },
         {

--- a/interpreter/terminal_interface/validate_llm_settings.py
+++ b/interpreter/terminal_interface/validate_llm_settings.py
@@ -39,6 +39,7 @@ def validate_llm_settings(interpreter):
                 "gpt-4",
                 "gpt-3.5-turbo",
                 "gpt-4o",
+                "gpt-4o-mini",
                 "gpt-4-turbo",
             ]:
                 if (
@@ -52,7 +53,7 @@ def validate_llm_settings(interpreter):
                         """---
                     > OpenAI API key not found
 
-                    To use `gpt-4-turbo` (recommended) please provide an OpenAI API key.
+                    To use `gpt-4o` (recommended) please provide an OpenAI API key.
 
                     To use another language model, run `interpreter --local` or consult the documentation at [docs.openinterpreter.com](https://docs.openinterpreter.com/language-model-setup/).
                     

--- a/scripts/wtf.py
+++ b/scripts/wtf.py
@@ -373,7 +373,7 @@ def main():
             if wtf_model:
                 model = wtf_model
             else:
-                model = profile.get("llm", {}).get("model", "gpt-3.5-turbo")
+                model = profile.get("llm", {}).get("model", "gpt-4o-mini")
     except:
         model = "gpt-4o-mini"
 

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -13,6 +13,6 @@ system_message: |
   In general, try to **make plans** with as few steps as possible. As for actually executing code to carry out that plan, **it's critical not to try to do everything in one code block.** You should try something, print information about it, then continue from there in tiny, informed steps. You will never get it on the first try, and attempting it in one go will often lead to errors you cant see.
   You are capable of **any** task.
 offline: false
-llm.model: "gpt-3.5-turbo"
+llm.model: "gpt-4o-mini"
 llm.temperature: 0.25
 verbose: true


### PR DESCRIPTION
### Describe the changes you have made:
- Updated all usages of gpt-3.5-turbo to gpt-4o-mini because its cheaper and more capable
- Updated a few leftover defaults from gpt-4-turbo to gpt-4o
- Added gpt-4o-mini to list of models that ask user for openai key
- Updated version numbers on fast.yaml and vision.yaml profiles

### Reference any relevant issues (e.g. "Fixes #000"):
- Fixed "We have updated our profile file format. Would you like to migrate your profile file to the new format? No data will be lost."

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
