### PR TITLE
Fixed disable_telemetry being overwritten to False

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -57,7 +57,7 @@ class OpenInterpreter:
             "Let me know what you'd like to do next.",
             "Please provide more information.",
         ],
-        disable_telemetry=os.getenv("DISABLE_TELEMETRY", "false").lower() == "true",
+        disable_telemetry=False,
         in_terminal_interface=False,
         conversation_history=True,
         conversation_filename=None,

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -478,6 +478,7 @@ Use """ to write multi-line messages.
     ### Set attributes on interpreter, because the arguments passed in via the CLI should override profile
 
     set_attributes(args, arguments)
+    interpreter.disable_telemetry=os.getenv("DISABLE_TELEMETRY", "false").lower() == "true" or args.disable_telemetry
 
     ### Set some helpful settings we know are likely to be true
 


### PR DESCRIPTION
### Describe the changes you have made:
- disable_telemetry was reading env var too early and being overwritten by set_attributes
- Moved reading of the env var to after set_attributes initializes the defaults
- This fixes the setting not using the environment variable

### Reference any relevant issues (e.g. "Fixes #000"):
Fixes https://github.com/OpenInterpreter/open-interpreter/issues/1410

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
