### PR TITLE
line breaker character made invalid for filenames

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -269,7 +269,7 @@ class OpenInterpreter:
                         first_few_words = "_".join(first_few_words_list[:-1])
                     else:  # for languages like Chinese without blank between words
                         first_few_words = self.messages[0]["content"][:15]
-                    for char in '<>:"/\\|?*!':  # Invalid characters for filenames
+                    for char in '<>:"/\\|?*!\n':  # Invalid characters for filenames
                         first_few_words = first_few_words.replace(char, "")
 
                     date = datetime.now().strftime("%B_%d_%Y_%H-%M-%S")


### PR DESCRIPTION
### made the line breaker character invalid as part of a filename
### Fixes #1404 
### Pre-Submission Checklist

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests 
- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
