### PR TITLE
Fixes #925: Exiting by Ctrl-D throws EOFError

### DIFF
--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -92,11 +92,16 @@ def terminal_interface(interpreter, message):
                 interpreter.messages = interpreter.messages[:-1]
             else:
                 ### This is the primary input for Open Interpreter.
-                message = (
-                    cli_input("> ").strip()
-                    if interpreter.multi_line
-                    else input("> ").strip()
-                )
+                try:
+                    message = (
+                        cli_input("> ").strip()
+                        if interpreter.multi_line
+                        else input("> ").strip()
+                    )
+                except (KeyboardInterrupt, EOFError):
+                    # Treat Ctrl-D on an empty line the same as Ctrl-C by exiting gracefully
+                    interpreter.display_message("\n\n`Exiting...`")
+                    raise KeyboardInterrupt
 
             try:
                 # This lets users hit the up arrow key for past messages


### PR DESCRIPTION
### Describe the changes you have made:

Catch both `KeyboardInterrupt` (Ctrl-C) and `EOFError` (Ctrl-D) exceptions on prompt input to exit gracefully.

### Reference any relevant issues (e.g. "Fixes #000"):

Fixes #925

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [X] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
