### PR TITLE
Update computer-api.mdx – fix typo

### DIFF
--- a/docs/code-execution/computer-api.mdx
+++ b/docs/code-execution/computer-api.mdx
@@ -35,7 +35,7 @@ Performs a hotkey on the computer
 
 
 ```python
-interpreter.computer.keboard.hotkey(" ", "command")
+interpreter.computer.keyboard.hotkey(" ", "command")
 ```
 
 


### PR DESCRIPTION
fixed typo. From `keboard` to `keyboard`.

### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ x] I have included relevant documentation updates (stored in /docs)
- [x ] I have read `docs/CONTRIBUTING.md`
- [ x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
