### PR TITLE
Fix: Change date format string for Windows compatibility

### DIFF
--- a/interpreter/computer_use/loop.py
+++ b/interpreter/computer_use/loop.py
@@ -101,7 +101,7 @@ SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>
 * You have access to a code editor tool for viewing and modifying source code files.
 * You can install and use command-line applications and development tools as needed.
 * When dealing with large outputs, use redirection to temporary files and tools like `grep` or the str_replace_editor to analyze the content efficiently.
-* The current date is {datetime.today().strftime('%A, %B %-d, %Y')}.
+* The current date is {datetime.today().strftime('%A, %B %d, %Y')}.
 </SYSTEM_CAPABILITY>"""
 
 SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>

--- a/interpreter/computer_use/loop.py
+++ b/interpreter/computer_use/loop.py
@@ -101,7 +101,7 @@ SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>
 * You have access to a code editor tool for viewing and modifying source code files.
 * You can install and use command-line applications and development tools as needed.
 * When dealing with large outputs, use redirection to temporary files and tools like `grep` or the str_replace_editor to analyze the content efficiently.
-* The current date is {datetime.today().strftime('%A, %B %d, %Y')}.
+* The current date is {datetime.today().strftime('%A, %B %#d, %Y' if platform.system() == 'Windows' else '%A, %B %-d, %Y')}.
 </SYSTEM_CAPABILITY>"""
 
 SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>


### PR DESCRIPTION
# Fix date format string for Windows compatibility

## Problem
When running `interpreter --os` on Windows, the program crashes with a ValueError due to an incompatible date format string (`%-d`).

## Solution
Changed the date format string from `%-d` to `%d` to ensure compatibility with Windows systems.

## Changes
- Modified `interpreter/computer_use/loop.py` to use Windows-compatible date format
- Replaced `%-d` with `%d` in `strftime()` call

## Testing
Tested on:
- Windows 11
- Python 3.11
- open-interpreter 0.4.1

The fix allows the program to start normally with the `--os` flag on Windows.

Fixes #1495