### PR TITLE
Improve truncation

### DIFF
--- a/interpreter/core/utils/truncate_output.py
+++ b/interpreter/core/utils/truncate_output.py
@@ -9,8 +9,11 @@ def truncate_output(data, max_output_chars=2800, add_scrollbars=False):
 
     message = ("Output truncated. "
                f"Showing {chars_per_end} characters from start/end. "
-               "You should try again and use computer.ai.summarize(output) "
-               "over the output, or break it down into smaller steps.\n\n")
+               "To handle large outputs, store result in python var first "
+               "`result = command()` then `computer.ai.summarize(result)` for "
+               "a summary, search with `result.find('text')`, "
+               "repeat shell commands with wc/grep/sed, etc. or break it down "
+               "into smaller steps.\n\n")
 
     # This won't work because truncated code is stored in interpreter.messages :/
     # If the full code was stored, we could do this:

--- a/interpreter/core/utils/truncate_output.py
+++ b/interpreter/core/utils/truncate_output.py
@@ -4,7 +4,13 @@ def truncate_output(data, max_output_chars=2800, add_scrollbars=False):
 
     needs_truncation = False
 
-    message = f"Output truncated. Showing the last {max_output_chars} characters. You should try again and use computer.ai.summarize(output) over the output, or break it down into smaller steps.\n\n"
+    # Calculate how much to show from start and end
+    chars_per_end = max_output_chars // 2
+
+    message = ("Output truncated. "
+               f"Showing {chars_per_end} characters from start/end. "
+               "You should try again and use computer.ai.summarize(output) "
+               "over the output, or break it down into smaller steps.\n\n")
 
     # This won't work because truncated code is stored in interpreter.messages :/
     # If the full code was stored, we could do this:
@@ -22,6 +28,8 @@ def truncate_output(data, max_output_chars=2800, add_scrollbars=False):
 
     # If data exceeds max length, truncate it and add message
     if len(data) > max_output_chars or needs_truncation:
-        data = message + data[-max_output_chars:]
+        first_part = data[:chars_per_end]
+        last_part = data[-chars_per_end:]
+        data = message + first_part + "\n[...]\n" + last_part
 
     return data


### PR DESCRIPTION
### Describe the changes you have made:

When truncating long outputs, remove the middle and show the head and tail to the assistant, instead of showing only the tail.  This provides more useful context.  

Also improve the suggestions given to the assistant for how to deal with long output, since it tends to do the wrong thing here.

### Reference any relevant issues (e.g. "Fixes #000"):

I don't see any.

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`  [but running `black` and `isort` on the code caused many unrelated changes, so I didn't commit that.]
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
