### PR TITLE
Add note about .env files from parent folders

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -3,6 +3,9 @@ import os
 os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 import sys
 
+# Note: litellm in DEV mode will load .env files from the current directory
+# and all parent directories. This can lead to unexpected API keys being loaded
+# if there are .env files in parent folders.
 import litellm
 
 litellm.suppress_debug_info = True


### PR DESCRIPTION
It was extremely confusing to me why an API key was being used within VSCode terminal that wasn't my OpenInterpreter key. This note might save other people time.

### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
