### PR TITLE
Remove duplicate server init, add server info prints

### DIFF
--- a/interpreter/cli.py
+++ b/interpreter/cli.py
@@ -186,12 +186,6 @@ async def async_load_interpreter(args):
 async def async_main(args):
     global global_interpreter
 
-    if args["serve"]:
-        global_interpreter = await async_load_interpreter(args)
-        print("Starting server...")
-        global_interpreter.server()
-        return
-
     if (
         args["input"] is None
         and sys.stdin.isatty()

--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -1073,6 +1073,21 @@ Notes for using the `str_replace` command:
         # Create and start server
         server = Server(self)
         try:
+            host = server.host
+            port = server.port
+
+            print("\n" + "=" * 60)
+            print(f"Open Interpreter API Server")
+            print("=" * 60)
+            print("\nTo use with an OpenAI-compatible client, configure:")
+            print(f"  - API Base:     http://{host}:{port}")
+            print(f"  - API Path:     /chat/completions")
+            print(f"  - API Key:      (any value, authentication not required)")
+            print(f"  - Model name:   (any value, ignored)")
+            print("\nNOTE: The server will use the model configured in --model")
+            print(f"      Currently using: {self.model}")
+            print("=" * 60 + "\n")
+
             server.run()
         except KeyboardInterrupt:
             print("\nShutting down server...")


### PR DESCRIPTION
### Describe the changes you have made:

1. Remove duplicate server init that can't be reached.
2. Print OpenAI API settings that need to be used in client:

Example:

````shell
(oi_dev) λ interpreter --serve --model gpt-4o-mini --auto-run
Starting OpenAI-compatible server...

============================================================
Open Interpreter API Server
============================================================

To use with an OpenAI-compatible client, configure:
  - API Base:     http://127.0.0.1:8000/
  - API Path:     /chat/completions
  - API Key:      (any value, authentication not required)
  - Model name:   (any value, ignored)

NOTE: The server will use the model configured in --model
      Currently using: gpt-4o-mini
============================================================
````

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
