### PR TITLE
Fix the type error of temperature initialization in Llm class

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -52,7 +52,7 @@ class Llm:
 
         # Settings
         self.model = "gpt-4o"
-        self.temperature = 0
+        self.temperature = 0.0
 
         self.supports_vision = None  # Will try to auto-detect
         self.vision_renderer = (


### PR DESCRIPTION
### Describe the changes you have made:

Change the temperature initialization of Llm class in interpreter/core/llm/llm.py.

Before: 
```python 
self.temperature = 0
```
After:
```python
self.temperature = 0.0
```

This change makes sure that the type of `self.temperature` is always `float` rather than `int`, which is more reliable and friendly for type checking.

### Reference any relevant issues (e.g. "Fixes #000"):
None.

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [x] I have read `docs/CONTRIBUTING.md`
- [x] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
